### PR TITLE
Indexfix

### DIFF
--- a/SwiftNES.xcodeproj/project.pbxproj
+++ b/SwiftNES.xcodeproj/project.pbxproj
@@ -26,7 +26,6 @@
 		66796ECA1CDCD2F80015E810 /* APU.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66796EC91CDCD2F80015E810 /* APU.swift */; };
 		668B05F21CE1515600315BCD /* APUChannels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 668B05F11CE1515600315BCD /* APUChannels.swift */; };
 		668B05F41CE28D4500315BCD /* APUBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 668B05F31CE28D4500315BCD /* APUBuffer.swift */; };
-		668CB6BA1D71F1A300E74FCF /* smb3.nes in Resources */ = {isa = PBXBuildFile; fileRef = 668CB6B91D71F1A300E74FCF /* smb3.nes */; };
 		668CB6BC1D72104100E74FCF /* MacControllerIO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 668CB6BB1D72104100E74FCF /* MacControllerIO.swift */; };
 		668CB6C01D73298A00E74FCF /* iOSControllerIO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 668CB6BF1D73298A00E74FCF /* iOSControllerIO.swift */; };
 		66A9C4371CA2EF3800936DBC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66A9C4361CA2EF3800936DBC /* AppDelegate.swift */; };
@@ -92,7 +91,6 @@
 		66796EC91CDCD2F80015E810 /* APU.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = APU.swift; path = Implementation/APU.swift; sourceTree = "<group>"; };
 		668B05F11CE1515600315BCD /* APUChannels.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = APUChannels.swift; path = Implementation/APUChannels.swift; sourceTree = "<group>"; };
 		668B05F31CE28D4500315BCD /* APUBuffer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = APUBuffer.swift; path = Implementation/APUBuffer.swift; sourceTree = "<group>"; };
-		668CB6B91D71F1A300E74FCF /* smb3.nes */ = {isa = PBXFileReference; lastKnownFileType = file; name = smb3.nes; path = ../../../testROMs/games/smb3.nes; sourceTree = "<group>"; };
 		668CB6BB1D72104100E74FCF /* MacControllerIO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MacControllerIO.swift; path = Implementation/MacControllerIO.swift; sourceTree = "<group>"; };
 		668CB6BF1D73298A00E74FCF /* iOSControllerIO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = iOSControllerIO.swift; sourceTree = "<group>"; };
 		66A9C4331CA2EF3800936DBC /* SwiftNES.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftNES.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -236,7 +234,6 @@
 				66C0E7FE1D171FE3008F6C3D /* Assets.xcassets */,
 				66C0E8001D171FE3008F6C3D /* LaunchScreen.storyboard */,
 				66C0E8031D171FE3008F6C3D /* Info.plist */,
-				668CB6B91D71F1A300E74FCF /* smb3.nes */,
 			);
 			path = "SwiftNES-iOS";
 			sourceTree = "<group>";
@@ -338,6 +335,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -375,7 +373,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				66C0E8021D171FE3008F6C3D /* LaunchScreen.storyboard in Resources */,
-				668CB6BA1D71F1A300E74FCF /* smb3.nes in Resources */,
 				66C0E7FF1D171FE3008F6C3D /* Assets.xcassets in Resources */,
 				66C0E7FD1D171FE3008F6C3D /* Main.storyboard in Resources */,
 			);
@@ -529,6 +526,7 @@
 				SDKROOT = macosx;
 				SWIFT_ENFORCE_EXCLUSIVE_ACCESS = none;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -571,6 +569,7 @@
 				SWIFT_DISABLE_SAFETY_CHECKS = YES;
 				SWIFT_ENFORCE_EXCLUSIVE_ACCESS = none;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -587,7 +586,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.appcannon.SwiftNES;
 				PRODUCT_NAME = SwiftNES;
 				SWIFT_DISABLE_SAFETY_CHECKS = YES;
-				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -606,7 +604,6 @@
 				PRODUCT_NAME = SwiftNES;
 				SWIFT_DISABLE_SAFETY_CHECKS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -655,7 +652,6 @@
 				PROVISIONING_PROFILE_SPECIFIER = "Provisioning Profile";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -676,7 +672,6 @@
 				PROVISIONING_PROFILE = "58860516-5541-401d-b7b6-352ee966f14b";
 				PROVISIONING_PROFILE_SPECIFIER = "Provisioning Profile";
 				SDKROOT = iphoneos;
-				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};

--- a/SwiftNES.xcodeproj/project.pbxproj
+++ b/SwiftNES.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		66C0E80B1D172024008F6C3D /* MetalKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 66C0E8091D172024008F6C3D /* MetalKit.framework */; };
 		66E186901CADB97300EFF583 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66E1868F1CADB97300EFF583 /* Logger.swift */; };
 		66F46AB91CB039B9005B637E /* PPU.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66F46AB81CB039B9005B637E /* PPU.swift */; };
+		A2EA39012975E3BF00DA3D91 /* Utility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 665F33E01F7FE01E00A24DAE /* Utility.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -435,6 +436,7 @@
 				668CB6C01D73298A00E74FCF /* iOSControllerIO.swift in Sources */,
 				66B2A31E1D1721ED00538CC1 /* Logger.swift in Sources */,
 				66B2A3221D1721ED00538CC1 /* APUBuffer.swift in Sources */,
+				A2EA39012975E3BF00DA3D91 /* Utility.swift in Sources */,
 				66B2A3211D1721ED00538CC1 /* APUChannels.swift in Sources */,
 				66C0E7F81D171FE3008F6C3D /* AppDelegate.swift in Sources */,
 				66B2A3201D1721ED00538CC1 /* APU.swift in Sources */,

--- a/SwiftNES.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/SwiftNES.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/SwiftNES/AppDelegate.swift
+++ b/SwiftNES/AppDelegate.swift
@@ -44,7 +44,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, MTKViewDelegate {
 	var sizingRect: NSRect? = nil
 	
 	private var texture: MTLTexture! = nil
-	private var textureOptions = [MTKTextureLoaderOptionTextureUsage: Int(MTLTextureUsage.renderTarget.rawValue) as NSNumber]
+    private var textureOptions = [MTKTextureLoader.Option.textureUsage: Int(MTLTextureUsage.renderTarget.rawValue) as NSNumber]
 	private var textureDescriptor: MTLTextureDescriptor? = nil
 	
 	private let threadGroupCount = MTLSizeMake(8, 8, 1)
@@ -181,7 +181,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, MTKViewDelegate {
 		
 		paused = true
 		
-		if(openDialog.runModal() == NSFileHandlingPanelOKButton) {
+        if(openDialog.runModal() == .OK) {
 			let _ = loadROM(openDialog.url!)
 		}
 		
@@ -227,7 +227,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, MTKViewDelegate {
 	}
 	
 	
-	override func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
+	func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
 		if(menuItem == playPauseEmulationButton) {
 			return fileLoaded
 		}
@@ -254,7 +254,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, MTKViewDelegate {
 			return false
 		}
 		
-		NSDocumentController.shared().noteNewRecentDocumentURL(url)
+		NSDocumentController.shared.noteNewRecentDocumentURL(url)
 		
 		playPauseEmulationButton.isEnabled = true
 		
@@ -325,20 +325,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate, MTKViewDelegate {
 	
 	// MARK: - Graphics
 	
-	func render(_ screen: inout [UInt32]) {
+	func render(_ screen: UnsafeMutablePointer<UInt32>) {
 		let width = Int(256 * scalingFactor)
 		let height = Int(240 * scalingFactor)
 		
 		let bytesPerPixel = 4
 		let bytesPerRow = width * bytesPerPixel
-		
-        metalView.currentDrawable!.texture.replace(region: MTLRegionMake2D(0, 0, width, height), mipmapLevel: 0, withBytes: UnsafeRawPointer(screen), bytesPerRow: bytesPerRow)
+        
+        metalView.framebufferOnly = false
+        metalView.currentDrawable!.texture.replace(region: MTLRegionMake2D(0, 0, width, height),
+                                                   mipmapLevel: 0,
+                                                   withBytes: screen,
+                                                   bytesPerRow: bytesPerRow)
 		
         let commandBuffer = commandQueue.makeCommandBuffer()
 		
-		commandBuffer.present(metalView.currentDrawable!)
+        commandBuffer?.present(metalView.currentDrawable!)
 		
-		commandBuffer.commit()
+        commandBuffer?.commit()
 	}
 	
 	func applicationWillTerminate(_ aNotification: Notification) {

--- a/SwiftNES/Implementation/Logger.swift
+++ b/SwiftNES/Implementation/Logger.swift
@@ -32,7 +32,7 @@ final class Logger: NSObject {
 	func hexString<T : UnsignedInteger>(_ value: T, padding: Int) -> String {
 		var string = String(value, radix: 16)
 		
-		for _ in string.characters.count..<padding {
+		for _ in string.count..<padding {
 			string = "0" + string
 		}
 		

--- a/SwiftNES/Implementation/Mappers/Mapper.swift
+++ b/SwiftNES/Implementation/Mappers/Mapper.swift
@@ -26,9 +26,9 @@ class Mapper {
 	func read(_ address: UInt16) -> UInt8 {
 		switch address {
 			case 0x0000 ..< 0x1000:
-				return ppuMemory.banks[address]
+            return ppuMemory.banks[Int(address)]
 			case 0x1000 ..< 0x2000:
-				return ppuMemory.banks[address]
+            return ppuMemory.banks[Int(address)]
 			case 0x2000 ..< 0x6000:
 //				print("Invalid mapper 0 address \(address)")
 				break

--- a/SwiftNES/PPU.swift
+++ b/SwiftNES/PPU.swift
@@ -587,7 +587,7 @@ final class PPU: NSObject {
 					spriteAttributes = secondaryOAM[secondaryOAMIndex + 2]
 					spriteXCoord = secondaryOAM[secondaryOAMIndex + 3]
 					
-					spriteYShift = UInt16(scanline) - UInt16(spriteYCoord)
+					spriteYShift = UInt16(bitPattern: Int16(scanline) - Int16(spriteYCoord))
 					
 					if spriteYCoord == 0xFF {
 						spriteYShift = 0


### PR DESCRIPTION
Fixed the iOS compile issue "Cannot subscript a value of type '[UInt8]' with an index of type 'UInt16'" by including Utils file into the iOS target.