### PR TITLE
Load .nes via UIDocumentPickerViewController on iOS

### DIFF
--- a/SwiftNES-iOS/Info.plist
+++ b/SwiftNES-iOS/Info.plist
@@ -43,5 +43,28 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UTImportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>NES rom</string>
+			<key>UTTypeIconFiles</key>
+			<array/>
+			<key>UTTypeIdentifier</key>
+			<string>com.appcannon.SwiftNES-iOS.nes</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>nes</string>
+				</array>
+			</dict>
+		</dict>
+		<dict/>
+	</array>
 </dict>
 </plist>

--- a/SwiftNES-iOS/ViewController.swift
+++ b/SwiftNES-iOS/ViewController.swift
@@ -284,7 +284,12 @@ class ViewController: UIViewController, MTKViewDelegate {
 	}
 	
 	@IBAction func run(_ sender: AnyObject) {
-		print(loadROM(Bundle.main.url(forResource: "smb3", withExtension: "nes")!))
+        let documentPickerViewController =
+        UIDocumentPickerViewController(documentTypes: ["com.appcannon.SwiftNES-iOS.nes"],
+                                       in: .import)
+        documentPickerViewController.allowsMultipleSelection = false
+        documentPickerViewController.delegate = self
+        present(documentPickerViewController, animated: true)
 	}
 	
 	@IBAction func touchDown(_ sender: AnyObject) {
@@ -297,3 +302,15 @@ class ViewController: UIViewController, MTKViewDelegate {
 	
 }
 
+extension ViewController: UIDocumentPickerDelegate
+{
+    func documentPicker(_ controller: UIDocumentPickerViewController,
+                        didPickDocumentsAt urls: [URL]) {
+        if let url = urls.last {
+            print(loadROM(url))
+        }
+    }
+    
+    func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
+    }
+}

--- a/SwiftNES.xcodeproj/project.pbxproj
+++ b/SwiftNES.xcodeproj/project.pbxproj
@@ -308,6 +308,7 @@
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);

--- a/SwiftNES.xcodeproj/project.pbxproj
+++ b/SwiftNES.xcodeproj/project.pbxproj
@@ -297,9 +297,8 @@
 					};
 					66C0E7F41D171FE3008F6C3D = {
 						CreatedOnToolsVersion = 8.0;
-						DevelopmentTeam = 58JLRGUCJQ;
 						DevelopmentTeamName = "Adam Gastineau";
-						ProvisioningStyle = Manual;
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};
@@ -645,8 +644,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = 58JLRGUCJQ;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "SwiftNES-iOS/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -654,7 +654,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.appcannon.SwiftNES-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "58860516-5541-401d-b7b6-352ee966f14b";
-				PROVISIONING_PROFILE_SPECIFIER = "Provisioning Profile";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -667,8 +667,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = 58JLRGUCJQ;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "SwiftNES-iOS/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -676,7 +677,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.appcannon.SwiftNES-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "58860516-5541-401d-b7b6-352ee966f14b";
-				PROVISIONING_PROFILE_SPECIFIER = "Provisioning Profile";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;


### PR DESCRIPTION
Allows `.nes` files that are saved on a folder (local or iCloud) in the iOS Files app to be loaded by the app, so there is no need to distribute .nes files with the bundle or accidentally include them in the repository.